### PR TITLE
GH-5 | Recheck ad couting logic and add tests

### DIFF
--- a/server/__tests__/scrapers/bing-html-parser.test.ts
+++ b/server/__tests__/scrapers/bing-html-parser.test.ts
@@ -1,0 +1,98 @@
+import { BingHtmlParser } from '@server/scrapers/html-parsers/bing-html-parser';
+
+describe('BingHtmlParser', () => {
+  let bingHtmlParser: BingHtmlParser;
+
+  beforeEach(() => {
+    bingHtmlParser = new BingHtmlParser();
+  });
+
+  it('should correctly parse HTML and count ads and links with new selectors', () => {
+    const html = `
+      <div>
+        <li class="b_ad">Ad 1</li>
+        <div class="sb_add">Ad 2</div>
+        <a href="#">Link 1</a>
+        <a href="#">Link 2</a>
+        <div data-bm="some-data">Not an ad</div>
+        <a href="#">Link 3</a>
+      </div>
+    `;
+
+    const result = bingHtmlParser.parse(html);
+
+    expect(result.totalAds).toBe(2); // Should count li.b_ad and div.sb_add
+    expect(result.totalLinks).toBe(3);
+  });
+
+  it('should return 0 for ads and links if none are found', () => {
+    const html = '<div><p>No ads or links here.</p></div>';
+
+    const result = bingHtmlParser.parse(html);
+
+    expect(result.totalAds).toBe(0);
+    expect(result.totalLinks).toBe(0);
+  });
+
+  it('should handle empty HTML gracefully', () => {
+    const html = '';
+
+    const result = bingHtmlParser.parse(html);
+
+    expect(result.totalAds).toBe(0);
+    expect(result.totalLinks).toBe(0);
+  });
+
+  it('should count an element with both classes only once', () => {
+    const html = `
+      <div>
+        <li class="b_ad sb_add">Ad with both classes</li>
+        <a href="#">Link 1</a>
+      </div>
+    `;
+
+    const result = bingHtmlParser.parse(html);
+
+    expect(result.totalAds).toBe(1);
+    expect(result.totalLinks).toBe(1);
+  });
+
+  it('should count only the top-level ad in a parent-child relationship', () => {
+    const html = `
+      <div class="sb_add">
+        Parent Ad
+        <li class="b_ad">Child Ad</li>
+      </div>
+      <li class="b_ad">Another top-level Ad</li>
+    `;
+
+    const result = bingHtmlParser.parse(html);
+
+    expect(result.totalAds).toBe(2); // div.sb_add and the second li.b_ad
+    expect(result.totalLinks).toBe(0);
+  });
+
+  it('should count only the top-level ad in multi-level nesting', () => {
+    const html = `
+      <div class="sb_add">
+        Level 1 Ad
+        <div>
+          <span>
+            <li class="b_ad">Level 2 Ad</li>
+          </span>
+        </div>
+      </div>
+      <div class="some-other-div">
+        <div class="sb_add">
+          Level 1 Ad in other div
+          <li class="b_ad">Level 2 Ad in other div</li>
+        </div>
+      </div>
+    `;
+
+    const result = bingHtmlParser.parse(html);
+
+    expect(result.totalAds).toBe(2); // The two outermost .sb_add divs
+    expect(result.totalLinks).toBe(0);
+  });
+});

--- a/server/scrapers/html-parsers/bing-html-parser.ts
+++ b/server/scrapers/html-parsers/bing-html-parser.ts
@@ -4,7 +4,13 @@ import * as cheerio from 'cheerio';
 export class BingHtmlParser implements HtmlParsingStrategy {
   parse(html: string) {
     const $ = cheerio.load(html);
-    const totalAds = $('.sb_add, .ads, .b_ad, [data-bm]').length;
+    const adSelector = '.b_ad, .sb_add';
+    const $ads = $(adSelector);
+
+    const totalAds = $ads.filter((_, element) => {
+      return $(element).parents(adSelector).length === 0;
+    }).length;
+
     const totalLinks = $('a').length;
     return { totalAds, totalLinks };
   }


### PR DESCRIPTION
- Review and fixed ad counting logic, there was an error before: I count the [data-bm] attribute which was a very common attribute on the page. Now I only count for .b_ad, .sb_add.
- I also handled the case where one element had all those classes, or, in a nested component where the parent element had one class and the child element had the other class. In such cases, I only count once.
- In case where one parent had one class, and it has multiple children, each children have another class, I will only count the parent once. It may seem like a bug but I don't think we will see this structure on a real HTML page. Also, recursively searching for ads within the children of each component will impact the performance -> not a priority at the moment.
- Add more tests for the counting logic.